### PR TITLE
Fix Local Path

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -1,5 +1,5 @@
 # Device path
-LOCAL_PATH := device/UMIDIGI/one_max
+LOCAL_PATH := device/umidigi/one_max
 
 # Architecture
 TARGET_ARCH := arm64


### PR DESCRIPTION
The local path was messed up due to capitalization of OEM in LOCAL_PATH due to which the build was failing here (https://jenkins.twrp.me/view/test/job/one_max-test/2/console)

Signed-off-by: chankruze <chankruze@gmail.com>